### PR TITLE
Add operation headings

### DIFF
--- a/docs/api/task.md
+++ b/docs/api/task.md
@@ -9,7 +9,6 @@ Base endpoint
 {server_url}/tasks
 ```
 
-
 Contains information about tasks stored for the users of the service.
 
 **This is a new line of text added for assignment 3!**
@@ -42,7 +41,11 @@ Sample `task` resource
 | `warning` | Number | The number of minutes relative to the `due_date` to alert the user of the task. This is normally a negative number to alert the user before the `due_date`.|
 | `id` | Number | The task's unique record ID |
 
-## READ
+## Operations
+
+The `task` resource supports these operations.
+
+## READ (GET)
 
 * [Get all tasks _(coming soon)_](#resource-properties)
 * [Get task by ID _(coming soon)_](#resource-properties)

--- a/docs/api/user.md
+++ b/docs/api/user.md
@@ -34,8 +34,15 @@ Sample `user` resource
 | `email` | string | The user's email address |
 | `id` | number | The user's unique record ID |
 
-## READ
+## Operations
+
+The `user` resource supports these operations.
+
+### READ (GET)
 
 * [Get all users](users-get-all-users)
 * [Get users by ID](users-get-user-by-id)
+
+### CREATE (POST)
+
 * [Create user](users-create-user)


### PR DESCRIPTION
Adds headings for the operations that the resource supports and separates the links by the operation the linked topic supports.