### PR TITLE
Add docs _config.yml file to show how to customize the documentation title

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+title: "To-Do Service"


### PR DESCRIPTION
The documentation configuration file is documented in:

- https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll
- https://jekyllrb.com/docs/configuration/